### PR TITLE
MBS-7072: Use ucol_open to open a UCollator

### DIFF
--- a/musicbrainz_collate.c
+++ b/musicbrainz_collate.c
@@ -86,7 +86,7 @@ static int32_t
 sortkey_from_unicode (UChar *input, uint8_t **output)
 {
     UErrorCode status = U_ZERO_ERROR;
-    UCollator * collator = ucol_openFromShortString ("", FALSE, NULL, &status);
+    UCollator * collator = ucol_open ("", &status);
     int32_t size;
 
     if (icu_failure (status))


### PR DESCRIPTION
It seems that ucol_openFromShortString has changed behaviour in
newer versions of libicu. Simply using ucol_open to open the root collator
with default settings appears to give us the desired sorting behaviour.
