### PR TITLE
Properly set PG_CPPFLAGS to allow compilation with homebrew icu4c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 MODULE_big   = musicbrainz_collate
 OBJS         = musicbrainz_collate.o
+PG_CPPFLAGS  = $(shell icu-config --cppflags)
 SHLIB_LINK   = $(shell icu-config --ldflags)
 PG_CONFIG    = pg_config
 PG91         = $(shell $(PG_CONFIG) --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)


### PR DESCRIPTION
OS X provides its own `libicucore.dylib` but nothing else, so `icu4c` has to be installed from homebrew to get the tools/headers. But it can't be linked into /usr/local because overriding the OS X lib would cause a bunch of problems. This adds a line to the Makefile that allows it to compile as long as `icu-config` is the the `$PATH` (in my case I have a symlink to it in ~/bin).