### PR TITLE
Fix extension installation (postgresql 9.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
 DATA_built = sql/$(EXTENSION)--$(EXTVERSION).sql
-DATA = $(wildcard sql/*--*.sql)
 endif
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
The xx--yy.sql file needs to be only in DATA_built, which the top-level
filter-out already correctly sets up.