### PR TITLE
Switch to pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 MODULE_big   = musicbrainz_collate
 OBJS         = musicbrainz_collate.o
-PG_CPPFLAGS  = $(shell icu-config --cppflags)
-SHLIB_LINK   = $(shell icu-config --ldflags)
+PG_CPPFLAGS  = $(shell pkg-config --cflags icu-i18n)
+SHLIB_LINK   = $(shell pkg-config --libs icu-i18n)
 PG_CONFIG    = pg_config
 PG91         = $(shell $(PG_CONFIG) --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)
 

--- a/README.musicbrainz_collate.md
+++ b/README.musicbrainz_collate.md
@@ -44,9 +44,10 @@ To use this extension you will need:
 
 - PostgreSQL version 8.3 or newer
 - libicu version 3.8 or newer
+- pkg-config
 
-You will need -dev packages installed for both of those, check that pg_config
-and icu-config are in your path.
+You will need -dev packages installed for libicu and PostgreSQL, check that
+pg_config is in your path.
 
 
 Installation


### PR DESCRIPTION
Debian Buster no longer ships ico-config.